### PR TITLE
Add a Token Check to the Invoke-ZARestRequest Private Function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
     "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
+    "powershell.codeFormatting.preset": "OTBS",
     "terminal.integrated.shell.windows": "c:/Program Files/PowerShell/6/pwsh.exe"
 }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,11 +1,9 @@
 
 
-## Initial Release
-
 ### Zerto Virtual Manager
 
-* Updated `Invoke-ZertoRestRequest` to work in Powershell 5.1 as well as Powershell core
+*
 
 ### Zerto Analytics
 
-* Implemented Zerto Analytics Functionality. Please see [Getting Started with Zerto Analytics](https://github.com/ZertoPublic/ZertoApiWrapper/wiki/Getting-Started-with-Zerto-Analytics)
+* Fixed an issue where the Zerto Analytics Rest Request function was not checking for the token before attempting a connection.

--- a/ZertoApiWrapper/Private/Invoke-ZARestRequest.ps1
+++ b/ZertoApiWrapper/Private/Invoke-ZARestRequest.ps1
@@ -12,7 +12,7 @@ function Invoke-ZARestRequest {
         Write-Error -Message "Zerto Analytics Connection does not Exist. Please run Connect-ZertoAnalytics first to establish a connection"
         break
     } elseif ( (Test-Path variable:script:zaHeaders) -and $([datetime]$script:zaLastAction).addMinutes(60) -lt $(get-date) ) {
-        Write-Error -Message "Authorization Token has Expired. Please re-authorize to the Zerto Virtual Manager"
+        Write-Error -Message "Authorization Token has Expired. Please re-authorize to the Zerto Analytics Portal"
         break
     } else {
         # Update the last action time and submit the request based on PS Version.

--- a/ZertoApiWrapper/Private/Invoke-ZARestRequest.ps1
+++ b/ZertoApiWrapper/Private/Invoke-ZARestRequest.ps1
@@ -11,7 +11,7 @@ function Invoke-ZARestRequest {
     if ( -not ((Test-Path variable:script:zaLastActionTime) -and (Test-Path variable:script:zaHeaders)) ) {
         Write-Error -Message "Zerto Analytics Connection does not Exist. Please run Connect-ZertoAnalytics first to establish a connection"
         break
-    } elseif ( (Test-Path variable:script:zaHeaders) -and $([datetime]$script:zaLastAction).addMinutes(60) -lt $(get-date) ) {
+    } elseif ( (Test-Path variable:script:zaHeaders) -and $([datetime]$script:zaLastActionTime).addMinutes(60) -lt $(get-date) ) {
         Write-Error -Message "Authorization Token has Expired. Please re-authorize to the Zerto Analytics Portal"
         break
     } else {

--- a/ZertoApiWrapper/Private/Invoke-ZARestRequest.ps1
+++ b/ZertoApiWrapper/Private/Invoke-ZARestRequest.ps1
@@ -7,14 +7,26 @@ function Invoke-ZARestRequest {
         [string]$contentType = "application/json"
     )
 
-    $submittedUri = "https://analytics.api.zerto.com/v2/{0}" -f $uri
-    if ($PSVersionTable.PSVersion.Major -ge 6) {
-        Invoke-RestMethod -Uri $submittedUri -Method $method -Body $body -Headers $Script:zaHeaders -ContentType $contentType -TimeoutSec 100
+    # Check to see if the required variables are present and currently valid
+    if ( -not ((Test-Path variable:script:zaLastActionTime) -and (Test-Path variable:script:zaHeaders)) ) {
+        Write-Error -Message "Zerto Analytics Connection does not Exist. Please run Connect-ZertoAnalytics first to establish a connection"
+        break
+    } elseif ( (Test-Path variable:script:zaHeaders) -and $([datetime]$script:zaLastAction).addMinutes(60) -lt $(get-date) ) {
+        Write-Error -Message "Authorization Token has Expired. Please re-authorize to the Zerto Virtual Manager"
+        break
     } else {
-        if ([String]::IsNullOrEmpty($body)) {
-            Invoke-RestMethod -Uri $submittedUri -Method $method -Headers $Script:zaHeaders -ContentType $contentType -TimeoutSec 100
+        # Update the last action time and submit the request based on PS Version.
+        Set-Variable -Name zaLastActionTime -Scope Script -Value $(Get-date).Ticks
+        $submittedUri = "https://analytics.api.zerto.com/v2/{0}" -f $uri
+        if ($PSVersionTable.PSVersion.Major -ge 6) {
+            Invoke-RestMethod -Uri $submittedUri -Method $method -Body $body -Headers $Script:zaHeaders -ContentType $contentType -TimeoutSec 100
         } else {
-            Invoke-RestMethod -Uri $submittedUri -Method $method -Headers $Script:zaHeaders -ContentType $contentType -TimeoutSec 100 -Body $body
+            # With PS 5, you cannot ship a $null body, check for $body variable and select correct Invoke request.
+            if ([String]::IsNullOrEmpty($body)) {
+                Invoke-RestMethod -Uri $submittedUri -Method $method -Headers $Script:zaHeaders -ContentType $contentType -TimeoutSec 100
+            } else {
+                Invoke-RestMethod -Uri $submittedUri -Method $method -Headers $Script:zaHeaders -ContentType $contentType -TimeoutSec 100 -Body $body
+            }
         }
     }
 }

--- a/ZertoApiWrapper/ZertoApiWrapper.psd1
+++ b/ZertoApiWrapper/ZertoApiWrapper.psd1
@@ -69,7 +69,7 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = 'Add-ZertoPeerSite', 'Checkpoint-ZertoVpg', 'Connect-ZertoServer', 'Disconnect-ZertoServer', 'Edit-ZertoVra', 'Export-ZertoVpg', 'Get-ZertoAlert', 'Get-ZertoDatastore', 'Get-ZertoEvent', 'Get-ZertoLicense', 'Get-ZertoLocalSite', 'Get-ZertoPeerSite', 'Get-ZertoProtectedVm', 'Get-ZertoRecoveryReport', 'Get-ZertoResourcesReport', 'Get-ZertoServiceProfile', 'Get-ZertoTask', 'Get-ZertoUnprotectedVm', 'Get-ZertoVirtualizationSite', 'Get-ZertoVolume', 'Get-ZertoVpg', 'Get-ZertoVpgSetting', 'Get-ZertoVra', 'Get-ZertoZorg', 'Get-ZertoZsspSession', 'Import-ZertoVpg', 'Install-ZertoVra', 'Invoke-ZertoFailover', 'Invoke-ZertoFailoverCommit', 'Invoke-ZertoFailoverRollback', 'Invoke-ZertoForceSync', 'Invoke-ZertoMove', 'Invoke-ZertoMoveCommit', 'Invoke-ZertoMoveRollback', 'New-ZertoVpg', 'New-ZertoVpgSettingsIdentifier', 'Remove-ZertoPeerSite', 'Remove-ZertoVpg', 'Resume-ZertoVpg', 'Save-ZertoVpgSettings', 'Set-ZertoAlert', 'Set-ZertoLicense', 'Start-ZertoCloneVpg', 'Start-ZertoFailoverTest', 'Stop-ZertoCloneVpg', 'Stop-ZertoFailoverTest', 'Suspend-ZertoVpg', 'Uninstall-ZertoVra'
+    FunctionsToExport = '*'
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modify the `Invoke-ZARestRequest` function to ensure that a valid Authentication token exists and has not expired (60 Minute TTL since last request to the Zerto Analytics Portal).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #36 
Fixes #35  

## Motivation and Context
It was possible to attempt to run command against the Zerto Analytics portal without a valid session authorization token. The command would error out with a "General Authorization" error. This update will now test to ensure the token exists and is valid. If it is not an error will be outputted letting them know the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Good old fashioned manual testing:
* Attempted a ZA function with connecting to Zerto Analytics First
* Authenticated against Zerto Analytics and successfully ran a command
* Waited 60 minutes and attempted a ZA function and expected error was returned.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

