### PR TITLE
Add missing formatting variable to the Get-ZAVpg function

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -9,3 +9,4 @@
 ### Zerto Analytics
 
 * Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/36) where the Zerto Analytics Rest Request function was not checking for the token before attempting a connection.
+* Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/40) where the `Get-ZAVpg` method would return a 404 error when a `-vpgIdentifier` parameter was specified.

--- a/ZertoApiWrapper/Public/Get-ZAVpg.ps1
+++ b/ZertoApiWrapper/Public/Get-ZAVpg.ps1
@@ -28,7 +28,7 @@ function Get-ZAVpg {
         }
 
         vpg {
-            $uri = "{0}/$vpgIdentifier"
+            $uri = "{0}/$vpgIdentifier" -f $uri
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add missing formatting variable to the Get-ZAVpg function when a specific VPG is being searched for.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#40 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a bug

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All current automated tests passing.
Imported the updated module and ran this command:
```PowerShell
PS> get-zavpg -vpgidentifier "57f502ff-3c41-4aff-b20a-6638205b73cd" -verbose
```
Returned with expected output. No 404 error


## Screenshots (if appropriate):
![WindowsTerminal_uThKFQV3X1](https://user-images.githubusercontent.com/296549/61951593-762ed980-af7f-11e9-8540-89abb15a2372.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

