### PR TITLE
Update to add token parameter to Add-ZertoPeerSite

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,17 +2,9 @@
 
 ### Zerto Virtual Manager
 
-* Added two functions to aid in bulk updating of NIC information for protected VMs. ([Issue 38](https://github.com/ZertoPublic/ZertoApiWrapper/issues/38))
-  * [Export-ZertoVmNicSetting](https://github.com/ZertoPublic/ZertoApiWrapper/blob/Master/docs/Export-ZertoVmNicSettings.md)
-  * [Import-ZertoVmNicSetting](https://github.com/ZertoPublic/ZertoApiWrapper/blob/Master/docs/Import-ZertoVmNicSettings.md)
-* Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/43) where a VPG being created with a single VM member would not be parsed by the API correctly using PowerShell 5.1
+* [Zerto version 7.5 has been released.](https://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Release%20Notes.pdf) As part of this release Zerto has added API functionality that requires the following updates.
+  * A token is now required to pair two sites together. The need is discussed in [Issue 46](https://github.com/ZertoPublic/ZertoApiWrapper/issues/46). To implement this change a `-token` parameter has been added to the `Add-ZertoPeerSite` function.
 
 ### Zerto Analytics
 
-* Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/36) where the Zerto Analytics Rest Request function was not checking for the token before attempting a connection.
-* Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/40) where the `Get-ZAVpg` method would return a 404 error when a `-vpgIdentifier` parameter was specified.
-
 ### General Updates
-
-* Updated the way that tests are invoked and parsed to ensure that both source and built module files are tested. This will ensure that what is being shipped passes all tests along with testing of the source files.
-* Added additional parameter validation tests to several of the functions. On-going effort to complete stand alone unit testing of each function.

--- a/ZertoApiWrapper/Public/Add-ZertoPeerSite.ps1
+++ b/ZertoApiWrapper/Public/Add-ZertoPeerSite.ps1
@@ -6,21 +6,30 @@ function Add-ZertoPeerSite {
             Mandatory = $true,
             HelpMessage = "Target Hostname or IP address to pair the localsite to."
         )]
-        [ValidateScript( {$_ -match [IPAddress]$_ } )]
+        [ValidateScript( { $_ -match [IPAddress]$_ } )]
         [string]$targetHost,
         [Parameter(
             HelpMessage = "Target communication port. Default is 9081"
         )]
         [ValidateRange(1024, 65535)]
-        [int]$targetPort = 9081
+        [int]$targetPort = 9081,
+        [Parameter(
+            HelpMessage = "The generated token from the destination site. Note: This is only supported when both sites support pairing authentication. This was implemented to support ZVR 7.5 and later."
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string]$token
     )
 
     begin {
-        $baseUri = "peersites"
-        $body = @{"HostName" = $targetHost; "Port" = $targetPort}
     }
 
     process {
+        $baseUri = "peersites"
+        if ($PSBoundParameters.Keys.Contains("token")) {
+            $body = @{ "HostName" = $targetHost; "Port" = $targetPort; "Token" = $token }
+        } else {
+            $body = @{ "HostName" = $targetHost; "Port" = $targetPort }
+        }
         if ($PSCmdlet.ShouldProcess("Pairing with Site $targetHost")) {
             Invoke-ZertoRestRequest -uri $baseUri -body $($body | ConvertTo-Json) -method "POST"
         }

--- a/docs/Add-ZertoPeerSite.md
+++ b/docs/Add-ZertoPeerSite.md
@@ -13,7 +13,8 @@ Pairs the current Zerto Virtual Manager to the target Zerto Virtual Manager
 ## SYNTAX
 
 ```
-Add-ZertoPeerSite [-targetHost] <String> [[-targetPort] <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Add-ZertoPeerSite [-targetHost] <String> [[-targetPort] <Int32>] [-token <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,10 +24,17 @@ Pairs the current Zerto Virtual Manager to the target Zerto Virtual Manager by l
 
 ### Example 1
 ```powershell
-PS C:\> Add-ZertoPeerSite -targetHost "192.168.2.100" -targetPort "9081"
+PS C:\> Add-ZertoPeerSite -targetHost "192.168.2.100"
 ```
 
-Pairs the current Zerto Virtual Manager to the Zerto Virtual Manager at IP address 192.168.2.100.
+Pairs the current Zerto Virtual Manager to the Zerto Virtual Manager at IP address 192.168.2.100. Use this method when pairing Zerto Virtual Managers that are prior to version 7.5
+
+### Example 2
+```powershell
+PS C:\> Add-ZertoPeerSite -targetHost "192.168.2.100" -token "GeneratedFromTargetZVM"
+```
+
+Pairs the current Zerto Virtual Manager to the Zerto Virtual Manager at IP address 192.168.2.100. Use this method when pairing Zerto Virtual Managers that are version 7.5 or later.
 
 ## PARAMETERS
 
@@ -57,6 +65,21 @@ Aliases:
 Required: False
 Position: 1
 Default value: "9081"
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -token
+The generated token from the destination site. Note: This is only supported when both sites support pairing authentication. This was implemented to support ZVR 7.5 and later.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Import-ZertoVmNicSetting.md
+++ b/docs/Import-ZertoVmNicSetting.md
@@ -13,7 +13,7 @@ Using a CSV file, will import updated Live and Test network settings for protect
 ## SYNTAX
 
 ```
-Import-ZertoVmNicSetting [-InputFile] <String> [<CommonParameters>]
+Import-ZertoVmNicSetting [-InputFile] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -47,6 +47,36 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -57,4 +87,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
 [Zerto Virtual Manager REST API VpgSettings end point documentation](http://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Zerto%20Virtual%20Manager%20%28ZVM%29%20-%20vSphere%20Online%20Help/index.html#page/RestfulAPIs%2FStatusAPIs.5.110.html%23)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a parameter to the Add-ZertoPeerSite function to accept the pairing token. Also updated are the tests for this module and associated documentation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #46 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Required to updated API call requiring a pairing token when pairing Zerto 7.5 or above sites.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in my 7.5 Lab. In the screen shot below, the command is passed initially and fails. This is expected. When a token is passed, the sites pair together.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/296549/66239642-6db5f600-e6c8-11e9-896d-7afecba0dea3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

