### PR TITLE
Fixes Failover Test function

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,7 @@
   * A new function has been added; `New-ZertoPairingToken`. This function will allow users to generate a pairing authentication token from the target ZVM to be used in the pairing process. [Issue 47](https://github.com/ZertoPublic/ZertoApiWrapper/issues/47) covers additional details.
   * A new function has been added; `Invoke-ZertoEvacuateVra`. This function will allow users to evacuate a target VRA by specifying a Host Name, VRA Name, or VRA Identifier. All VMs currently replicating to the specified location will be migrated to different targets. [Issue 51](https://github.com/ZertoPublic/ZertoApiWrapper/issues/51)
   * A function has been added; `Copy-ZertoVpg`. This function will allow users to copy the settings of a single VPG and add new VMs to it. There is currently no customization beyond specifying the VMs to be placed in the newly created VPG. Should additional edits \ updates be required, they should be done post creation. [Issue 54](https://github.com/ZertoPublic/ZertoApiWrapper/issues/54)
+  * Fixed [issue 57](https://github.com/ZertoPublic/ZertoApiWrapper/issues/57) where a `Start-ZertoFailoverTest` would throw an error complaining about validating the body parameter. This has been fixed and tested against Zerto Virtual Manager 7.5 Update 1 with Windows PowerShell 5.1 and PowerShell Core 6.2.
 
 ### Zerto Analytics
 

--- a/ZertoApiWrapper/Public/Invoke-ZertoMove.ps1
+++ b/ZertoApiWrapper/Public/Invoke-ZertoMove.ps1
@@ -89,7 +89,7 @@ function Invoke-ZertoMove {
                 Write-Error "VPG: $name not found. Please check the name and try again. Skipping"
             } else {
                 $uri = "{0}/{1}/move" -f $baseUri, $vpgId
-                if ($PSCmdlet.ShouldProcess("Moving VPG: $name wiht settings: $($body | convertto-json)")) {
+                if ($PSCmdlet.ShouldProcess("Moving VPG: $name with settings: $($body | convertto-json)")) {
                     Invoke-ZertoRestRequest -uri $uri -method "POST" -body $($body | ConvertTo-Json)
                 }
             }

--- a/ZertoApiWrapper/Public/Start-ZertoFailoverTest.ps1
+++ b/ZertoApiWrapper/Public/Start-ZertoFailoverTest.ps1
@@ -27,11 +27,12 @@ function Start-ZertoFailoverTest {
         if ( -not $vpgIdentifier) {
             Write-Error "VPG: $vpgName Not Found. Please check the name and try again!" -ErrorAction Stop
         }
+        $body = @{ }
         if ( $PSBoundParameters.ContainsKey('vmName') ) {
             $vpgVmInformation = Get-ZertoProtectedVm -vpgName $vpgName
-            [System.Collections.ArrayList]$vmIdentifiers = @()
+            $vmIdentifiers = [System.Collections.Generic.List[string]]::new()
             foreach ( $name in $vmName ) {
-                $selectedVm = $vpgVmInformation | Where-Object {$_.VmName.toLower() -eq $name.toLower()}
+                $selectedVm = $vpgVmInformation | Where-Object { $_.VmName.toLower() -eq $name.toLower() }
                 if ($null -eq $selectedVm) {
                     Write-Error "VM: $name NOT found in VPG $vpgName. Check the name and try again." -ErrorAction Stop
                 } elseif ($vmIdentifiers.Contains($selectedVm.vmIdentifier.toString())) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified the `Start-ZertoFailoverTest` function to explicitly declare the `$body` variable to be passed to the API in the event that specific VMs are not called out.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #57 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug in the code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against my lab with both PowerShell Core and Windows PowerShell against ZVM 7.5U1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

