### PR TITLE
Remove -VpgIdentifier Parameter from Get-ZertoRecoveryReport function

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,9 +2,4 @@
 
 ### Zerto Virtual Manager
 
-* [Zerto version 7.5 has been released.](https://s3.amazonaws.com/zertodownload_docs/Latest/Zerto%20Virtual%20Replication%20Release%20Notes.pdf) As part of this release Zerto has added API functionality that requires the following updates.
-  * A token is now required to pair two sites together. The need is discussed in [Issue 46](https://github.com/ZertoPublic/ZertoApiWrapper/issues/46). To implement this change a `-token` parameter has been added to the `Add-ZertoPeerSite` function.
-  * A new function has been added; `New-ZertoPairingToken`. This function will allow users to generate a pairing authentication token from the target ZVM to be used in the pairing process. [Issue 47](https://github.com/ZertoPublic/ZertoApiWrapper/issues/47) covers additional details.
-* A new function has been added; `Invoke-ZertoEvacuateVra`. This function will allow users to evacuate a target VRA by specifying a Host Name, VRA Name, or VRA Identifier. All VMs currently replicating to the specified location will be migrated to different targets. [Issue 51](https://github.com/ZertoPublic/ZertoApiWrapper/issues/51)
-* A function has been added; `Copy-ZertoVpg`. This function will allow users to copy the settings of a single VPG and add new VMs to it. There is currently no customization beyond specifying the VMs to be placed in the newly created VPG. Should additional edits \ updates be required, they should be done post creation. [Issue 54](https://github.com/ZertoPublic/ZertoApiWrapper/issues/54)
-* Fixed [issue 57](https://github.com/ZertoPublic/ZertoApiWrapper/issues/57) where a `Start-ZertoFailoverTest` would throw an error complaining about validating the body parameter. This has been fixed and tested against Zerto Virtual Manager 7.5 Update 1 with Windows PowerShell 5.1 and PowerShell Core 6.2.
+* Addressed a reported [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/60) in the `Get-ZertoRecoveryReport` function where the `-VpgIdentifier` parameter was not working. This parameter is not accepted by the API as a valid filter and is ignored. This parameter has been removed from the function.

--- a/ZertoApiWrapper/Public/Get-ZertoRecoveryReport.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoRecoveryReport.ps1
@@ -28,12 +28,6 @@ function Get-ZertoRecoveryReport {
         [string]$pageSize,
         [Parameter(
             ParameterSetName = "filter",
-            HelpMessage = "The internal identifier of the VPG. You can specify more than one VPG, separated by commas."
-        )]
-        [ValidateNotNullOrEmpty()]
-        [string]$vpgIdentifier,
-        [Parameter(
-            ParameterSetName = "filter",
             HelpMessage = "The name of the VPG. You can specify more than one VPG, separated by commas."
         )]
         [ValidateNotNullOrEmpty()]

--- a/docs/Get-ZertoRecoveryReport.md
+++ b/docs/Get-ZertoRecoveryReport.md
@@ -142,22 +142,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -vpgIdentifier
-The internal identifier of the VPG.
-You can specify more than one VPG, separated by commas.
-
-```yaml
-Type: String
-Parameter Sets: filter
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -vpgName
 The name of the VPG.
 You can specify more than one VPG, separated by commas.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the `-vpgIdentifier` parameter from the `Get-ZertoRecoveryReport` function as it is unused.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #60 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The parameter is not accepted by the API and is ignored. Removing it from the function as an option.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built the module and the parameter was no longer an option. Ran all integrated tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

