### PR TITLE
Update Export and Import VpgNicSetting functions

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,3 +3,5 @@
 ### Zerto Virtual Manager
 
 * Addressed a reported [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/60) in the `Get-ZertoRecoveryReport` function where the `-VpgIdentifier` parameter was not working. This parameter is not accepted by the API as a valid filter and is ignored. This parameter has been removed from the function.
+* Addressed a reported [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/60) where the `Export-ZertoVpgNicSetting` function would not properly execute when run against a VM with no NICs attached.
+* In reviewing the `Export-ZertoVpgNicSetting`, a review of the `Import-ZertoVpgNicSetting` was completed and it was determined to update the import logic based on various test cases. Along with this, it is now possible to reset the NIC settings to the default state with the `Import-ZertoVpgNicSetting` command. Please review the [Import-ZertoVpgNicSetting help](https://github.com/ZertoPublic/ZertoApiWrapper/blob/master/docs/Import-ZertoVmNicSetting.md) to review the updated options and import logic.

--- a/ZertoApiWrapper/Public/Export-ZertoVmNicSetting.ps1
+++ b/ZertoApiWrapper/Public/Export-ZertoVmNicSetting.ps1
@@ -45,33 +45,37 @@ function Export-ZertoVmNicSetting {
             $null = Remove-ZertoVpgSettingsIdentifier -vpgSettingsIdentifier $settingsId
             $networkMap = Get-Map -InputObject $networks -key "NetworkIdentifier" -value "VirtualizationNetworkName"
             foreach ($vm in $vmSettings) {
-                $nicInfo = [PSCustomObject]@{
-                    VPGName              = $group.VPGName
-                    VMName               = $vmMap[$($vm.vmIdentifier)]
-                    NicIdentifier        = $vm.nics.NicIdentifier
-                    LiveNetwork          = $networkMap[$vm.nics.failover.Hypervisor.NetworkIdentifier]
-                    LiveShouldReplaceMac = $vm.nics.failover.Hypervisor.ShouldReplaceMacAddress
-                    LiveIsDHCP           = $vm.Nics.failover.Hypervisor.IpConfig.IsDhcp
-                    LiveIpAddress        = $vm.nics.failover.Hypervisor.IpConfig.StaticIp
-                    LiveIpSubnetMask     = $vm.nics.failover.Hypervisor.IpConfig.SubnetMask
-                    LiveIpDefaultGateway = $vm.nics.failover.Hypervisor.IpConfig.Gateway
-                    LivePrimaryDns       = $vm.nics.failover.Hypervisor.IpConfig.PrimaryDns
-                    LiveSecondayDns      = $vm.nics.failover.Hypervisor.IpConfig.SecondaryDns
-                    LiveDnsSuffix        = $vm.nics.failover.Hypervisor.DnsSuffix
-                    TestNetwork          = $networkMap[$vm.nics.failoverTest.Hypervisor.NetworkIdentifier]
-                    TestShouldReplaceMac = $vm.nics.failoverTest.Hypervisor.ShouldReplaceMacAddress
-                    TestIsDHCP           = $vm.Nics.failoverTest.Hypervisor.IpConfig.IsDhcp
-                    TestIpAddress        = $vm.nics.failoverTest.Hypervisor.IpConfig.StaticIp
-                    TestIpSubnetMask     = $vm.nics.failoverTest.Hypervisor.IpConfig.SubnetMask
-                    TestIpDefaultGateway = $vm.nics.failoverTest.Hypervisor.IpConfig.Gateway
-                    TestPrimaryDns       = $vm.nics.failoverTest.Hypervisor.IpConfig.PrimaryDns
-                    TestSecondayDns      = $vm.nics.failoverTest.Hypervisor.IpConfig.SecondaryDns
-                    TestDnsSuffix        = $vm.nics.failoverTest.Hypervisor.DnsSuffix
+                if ($vm.nics.count -gt 0) {
+                    foreach ($nic in $vm.nics) {
+                        $nicInfo = [PSCustomObject]@{
+                            VPGName              = $group.VPGName
+                            VMName               = $vmMap[$vm.vmIdentifier]
+                            NicIdentifier        = $nic.NicIdentifier
+                            LiveNetwork          = $networkMap[$nic.failover.Hypervisor.NetworkIdentifier]
+                            LiveShouldReplaceMac = $nic.failover.Hypervisor.ShouldReplaceMacAddress
+                            LiveIsDHCP           = $nic.failover.Hypervisor.IpConfig.IsDhcp
+                            LiveIpAddress        = $nic.failover.Hypervisor.IpConfig.StaticIp
+                            LiveIpSubnetMask     = $nic.failover.Hypervisor.IpConfig.SubnetMask
+                            LiveIpDefaultGateway = $nic.failover.Hypervisor.IpConfig.Gateway
+                            LivePrimaryDns       = $nic.failover.Hypervisor.IpConfig.PrimaryDns
+                            LiveSecondayDns      = $nic.failover.Hypervisor.IpConfig.SecondaryDns
+                            LiveDnsSuffix        = $nic.failover.Hypervisor.DnsSuffix
+                            TestNetwork          = $networkMap[$nic.failoverTest.Hypervisor.NetworkIdentifier]
+                            TestShouldReplaceMac = $nic.failoverTest.Hypervisor.ShouldReplaceMacAddress
+                            TestIsDHCP           = $nic.failoverTest.Hypervisor.IpConfig.IsDhcp
+                            TestIpAddress        = $nic.failoverTest.Hypervisor.IpConfig.StaticIp
+                            TestIpSubnetMask     = $nic.failoverTest.Hypervisor.IpConfig.SubnetMask
+                            TestIpDefaultGateway = $nic.failoverTest.Hypervisor.IpConfig.Gateway
+                            TestPrimaryDns       = $nic.failoverTest.Hypervisor.IpConfig.PrimaryDns
+                            TestSecondayDns      = $nic.failoverTest.Hypervisor.IpConfig.SecondaryDns
+                            TestDnsSuffix        = $nic.failoverTest.Hypervisor.DnsSuffix
+                        }
+                        $nicInfo
+                    }
                 }
-                $nicInfo
             }
         }
-        $nicSettings | Export-Csv -Path $OutputFile
+        $nicSettings | Export-Csv -Path $OutputFile -NoTypeInformation
     }
 
     end {

--- a/ZertoApiWrapper/Public/Import-ZertoVmNicSetting.ps1
+++ b/ZertoApiWrapper/Public/Import-ZertoVmNicSetting.ps1
@@ -51,7 +51,7 @@ function Import-ZertoVmNicSetting {
                     foreach ($nic in $VmNicSettings.nics) {
                         if ($nic.NicIdentifier -eq $vm.NicIdentifier) {
                             $NicUri = "{0}/nics/{1}" -f $uri, $nic.NicIdentifier
-                            Invoke-ZertoRestRequest -uri $NicUri -Method "DELETE"
+                            Invoke-ZertoRestRequest -uri $NicUri -Method "DELETE" > $null
                             $nicSettings = Invoke-ZertoRestRequest -uri $NicUri -Method "GET"
                             $nicSettings.failover.Hypervisor.NetworkIdentifier = $NetworkMap[$vm.LiveNetwork]
                             $nicSettings.failover.Hypervisor.ShouldReplaceMacAddress = $vm.LiveShouldReplaceMac

--- a/docs/Import-ZertoVmNicSetting.md
+++ b/docs/Import-ZertoVmNicSetting.md
@@ -19,7 +19,13 @@ Import-ZertoVmNicSetting [-InputFile] <String> [-WhatIf] [-Confirm] [<CommonPara
 ## DESCRIPTION
 Using a CSV file, will import updated Live and Test network settings for protected virtual machines. This function will read the provided CSV file and only update VMs defined in the file.
 
-It should be noted, due to current API limitations once a NIC is defined to update to either a Static IP address or use a DHCP address, it is not possible to remove that configuration via the API. Should you require this functionality, you will need to manually update via the GUI to set the option to "No"
+Each entry in the CSV will be for one VM and a single NIC attached to that VM. Each entry MUST contain the following information: VPG Name, VM Name, Network Adapter Name, Mac Address Update for both Live and Test, and Network Name for both Live and Test. All other information is optional, but will be applied based on the following logic:
+  * If 'IsDhcp' is set to 'TRUE', the NIC setting will be set to DHCP and Primary DNS, Secondary DNS, and Search Domain settings will be applied along with the mandatory fields.
+  * If 'IsDhcp' is set to 'FALSE' or not set and there is an IP Address defined, the IP Address, Subnet Mask, Default Gateway, Primary DNS, Secondary DNS, and Search Domain settings will be applied along with the mandatory fields.
+  * if 'IsDhcp' is set to 'FALSE' or not set and there is NOT an IP Address defined, the current NIC settings will be removed and ONLY the mandatory fields will be applied.
+
+This logic is applied to both the Live and Test settings individually. It is recommended to use the `Export-ZertoVpgNicSetting` to dump all current settings and then modify a copy of the exported file with only the settings you wish to update. Import the copied file and if you need to revert, Import the original.
+
 
 ## EXAMPLES
 

--- a/docs/Import-ZertoVmNicSetting.md
+++ b/docs/Import-ZertoVmNicSetting.md
@@ -1,7 +1,7 @@
 ---
 external help file: ZertoApiWrapper-help.xml
 Module Name: ZertoApiWrapper
-online version: https://github.com/ZertoPublic/ZertoApiWrapper/blob/master/docs/Get-ZertoZsspSession.md
+online version: https://github.com/ZertoPublic/ZertoApiWrapper/blob/master/docs/Import-ZertoVmNicSetting.md
 schema: 2.0.0
 ---
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated two Functions:

1. `Export-ZertoVpgNicSetting` was updated to account for VMs that don't have any NICs attached to them and continue to export the data.
2. `Import-ZertoVpgNicSetting` was updated with updated logic when determining which settings to apply to the NIC being updated. This logic has been outlined in the help documentation.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #61 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When attempting to export settings that contain a VM with no NICs attached, the process will fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in my 7.0 and 7.5 Labs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

