### PR TITLE
Add functionality for ZVM 8.0

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,9 @@
 * Updated the `Install-ZertoVra` function to allow for installation of the VRA using the host password method. Please review the [Install-ZertoVra](https://github.com/ZertoPublic/ZertoApiWrapper/blob/master/docs/Install-ZertoVra.md) documentation for syntax and examples.
 * Updated the `Edit-ZertoVra` function to allow for modification of the associated ESX host password if the need arises. Please review the [Edit-ZertoVra](https://github.com/ZertoPublic/ZertoApiWrapper/blob/master/docs/Edit-ZertoVra.md) documentation for syntax and examples.
 * Added a new function, `Set-ZertoUserCredential`, to allow the updating of the username and password used to connect the Zerto Virtual Manager to the paired hypervisor. Please see the [Set-ZertoUserCredential](https://github.com/ZertoPublic/ZertoApiWrapper/blob/master/docs/Set-ZertoUserCredential.md) help for additional information.
+* With the release of [Zerto 8.0](https://www.zerto.com/zerto-8-0-general-availability/) some additional API endpoints have become available.
+  * Updated `Get-ZertoVirtualizationSite` to add the `-repository` parameter to enable returning information for LTR repositories.
+  * Updated `Get-ZertoVpgSetting` to add the `-ltr` parameter to enable returning information for current LTR settings for the selected VPG.
 
 ###  Zerto Analytics
 

--- a/Tests/Public/Get-ZertoVirtualizationSite.Tests.ps1
+++ b/Tests/Public/Get-ZertoVirtualizationSite.Tests.ps1
@@ -87,7 +87,7 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
         Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
             $uri -eq 'virtualizationsites/1234'
         } {
-            return (Get-Content "$global:here\Mocks\VirtualSite-siteId.json" -Raw) | ConvertFrom-Json
+            return (Get-Content "$global:here\Mocks\VirtualSite-SiteId.json" -Raw) | ConvertFrom-Json
         } -Verifiable
         Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
             $uri -eq 'virtualizationsites/1234/datastores'

--- a/Tests/Public/Get-ZertoVirtualizationSite.Tests.ps1
+++ b/Tests/Public/Get-ZertoVirtualizationSite.Tests.ps1
@@ -137,7 +137,8 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
 
         It "Should return a single site when a siteIdentifier is provided" {
             $results = Get-ZertoVirtualizationSite -siteIdentifier '1234'
-            $results.Count | Should -BeExactly 1
+            $results.VirtualizationSiteName | Should -BeExactly 'cavc.nc.lab'
+            $results.siteIdentifier | Should -BeExactly '8e1c9f53-4973-4a4a-b2dd-1ebb293614d8'
         }
 
         It "Should return a list of devices with the '-devices' switch" {
@@ -157,7 +158,8 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
 
         It "Should return a single host with the '-hosts' switch and hostIdentifier provided" {
             $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -hosts -hostIdentifier '4567'
-            $results.Count | Should -BeExactly 1
+            $results.VirtualizationHostName | Should -BeExactly "caesx3.nc.lab"
+            $results.hostIdentifier | Should -BeExactly "09db6c5b-b956-430f-9589-b58876ca377a.host-18"
         }
 
         It "Should return a list of datastores with the '-datastores' switch" {
@@ -167,12 +169,14 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
 
         It "Should return a list of datastores with the '-datastoreClusters' switch" {
             $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -datastoreClusters
-            $results.Count | Should -BeExactly 1
+            $results.DatastoreClusterIdentifier | Should -BeExactly "09db6c5b-b956-430f-9589-b58876ca377a.group-p44"
+            $results.DatastoreClusterName | Should -BeExactly "CA_DS_Cluster"
         }
 
         It "Should return a list of Networks with the '-networks' switch" {
             $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -networks
-            $results.Count | Should -BeExactly 1
+            $results.NetworkIdentifier | Should -BeExactly "09db6c5b-b956-430f-9589-b58876ca377a.network-20"
+            $results.VirtualizationNetworkName | Should -BeExactly "VM Network"
         }
 
         It "Should return a list of folders with the '-folders' switch" {
@@ -182,12 +186,14 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
 
         It "Should return a list of Host Clusters with the '-hostClusters' switch" {
             $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -hostClusters
-            $results.Count | Should -BeExactly 1
+            $results.ClusterIdentifier | Should -BeExactly "09db6c5b-b956-430f-9589-b58876ca377a.domain-c7"
+            $results.VirtualizationClusterName | Should -BeExactly "CA Cluster"
         }
 
         It "Should return a list of Resource Pools with the '-resourcePools' switch" {
             $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -resourcePools
-            $results.Count | Should -BeExactly 1
+            $results.ResourcePoolIdentifier | Should -BeExactly "09db6c5b-b956-430f-9589-b58876ca377a.resgroup-8"
+            $results.ResourcePoolName | Should -BeExactly "Resources"
         }
 
         It "Should return a list of VMs with the '-VMs' switch" {
@@ -197,7 +203,11 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
 
         It "Should return a list of LTR Repositories with the '-repositories' switch" {
             $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -repositories
-            $results.Count | Should -BeExactly 1
+            $results.ConnectionType | Should -BeExactly "ServerMessageBlock"
+            $results.RepositoryIdentifier | Should -BeExactly "120355ce-fcd0-4820-a971-787d0470793b"
+            $results.RepositoryName | Should -BeExactly "Synology"
+            $results.StorageType | Should -BeExactly "NetworkShare"
+            $results.Path | Should -not -be $null
         }
 
         Assert-VerifiableMock

--- a/Tests/Public/Get-ZertoVirtualizationSite.Tests.ps1
+++ b/Tests/Public/Get-ZertoVirtualizationSite.Tests.ps1
@@ -3,13 +3,247 @@ $global:here = (Split-Path -Parent $MyInvocation.MyCommand.Path)
 $global:function = ((Split-Path -leaf $MyInvocation.MyCommand.Path).Split('.'))[0]
 
 Describe $global:function -Tag 'Unit', 'Source', 'Built' {
+    BeforeAll {
+        $script:ScriptBlock = (Get-Command $global:function).ScriptBlock
+    }
 
     Context "$global:function::Parameter Unit Tests" {
+        It "$global:function should have exactly 23 parameters defined" {
+            (Get-Command $global:function).Parameters.Count | Should -Be 23
+        }
+
+        $ParameterTestCases = @(
+            @{ParameterName = 'siteIdentifier'; Type = 'String'; Mandatory = $true; Validation = 'NotNullOrEmpty' }
+            @{ParameterName = 'hostIdentifier'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }
+            @{ParameterName = 'folders'; Type = 'Switch'; Mandatory = $true; Validation = $Null }
+            @{ParameterName = 'hostClusters'; Type = 'Switch'; Mandatory = $true; Validation = $Null }
+            @{ParameterName = 'hosts'; Type = 'Switch'; Mandatory = $true; Validation = $Null }
+            @{ParameterName = 'networks'; Type = 'Switch'; Mandatory = $true; Validation = $Null }
+            @{ParameterName = 'resourcePools'; Type = 'Switch'; Mandatory = $true; Validation = $Null }
+            @{ParameterName = 'vms'; Type = 'Switch'; Mandatory = $true; Validation = $Null }
+            @{ParameterName = 'repositories'; Type = 'Switch'; Mandatory = $true; Validation = $Null }
+        )
+
+        It "<ParameterName> parameter is of <Type> type" -TestCases $ParameterTestCases {
+            param($ParameterName, $Type, $Mandatory)
+            Get-Command $global:function | Should -HaveParameter $ParameterName -Mandatory:$Mandatory -Type $Type
+        }
+
+        It "<ParameterName> parameter has correct validation setting of <Validation>"  -TestCases $ParameterTestCases {
+            param($ParameterName, $Type, $Validation)
+            $attrs = (Get-Command $global:function).Parameters[$ParameterName].Attributes
+            Switch ($Validation) {
+
+                'NotNullOrEmpty' {
+                    $attrs.Where{ $_ -is [ValidateNotNullOrEmpty] }.Count | Should -Be 1
+                }
+
+                $Null {
+                    $Type -match 'Switch' | Should -BeTrue -Because "Only Switch Parameters should not have validation"
+                }
+
+                default {
+                    $true | Should -BeFalse -Because "No Validation Selected. Review test cases"
+                }
+
+            }
+        }
+
+        It "$($global:function) does not have 'SupportsShouldProcess'" {
+            Get-Command $global:function | Should -not -HaveParameter WhatIf
+            Get-Command $global:function | Should -not -HaveParameter Confirm
+            $script:ScriptBlock | Should -not -match 'SupportsShouldProcess'
+            $script:ScriptBlock | Should -not -match '\$PSCmdlet\.ShouldProcess\(.+\)'
+        }
 
     }
 
     Context "$global:function::Parameter Functional Tests" {
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter  {
+            $uri -eq 'virtualizationsites'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-NoParams.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/devices'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-devices.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/devices?hostIdentifier=4567'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-devices-hostid.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/hosts'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-hosts.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/hosts/4567'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-hosts-hostid.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-siteId.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/datastores'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-datastores.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/datastoreclusters'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-datastoreClusters.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/networks'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-Networks.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/folders'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-Folders.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/hostclusters'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-hostClusters.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/resourcepools'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-ResourcePools.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/vms'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-VMs.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
+        Mock -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/repositories'
+        } {
+            return (Get-Content "$global:here\Mocks\VirtualSite-repositories.json" -Raw) | ConvertFrom-Json
+        } -Verifiable
 
+        It "Should return all known sites when called without parameters" {
+            $results = Get-ZertoVirtualizationSite
+            $results.Count | Should -BeExactly 2
+        }
+
+        It "Should return a single site when a siteIdentifier is provided" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234'
+            $results.Count | Should -BeExactly 1
+        }
+
+        It "Should return a list of devices with the '-devices' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -devices
+            $results.Count | Should -BeExactly 5
+        }
+
+        It "Should return a list of devices with the '-devices' switch and hostIdentifier provided" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -devices -hostIdentifier '4567'
+            $results.Count | Should -BeExactly 5
+        }
+
+        It "Should return a list of hosts with the '-hosts' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -hosts
+            $results.Count | Should -BeExactly 3
+        }
+
+        It "Should return a single host with the '-hosts' switch and hostIdentifier provided" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -hosts -hostIdentifier '4567'
+            $results.Count | Should -BeExactly 1
+        }
+
+        It "Should return a list of datastores with the '-datastores' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -datastores
+            $results.Count | Should -BeExactly 8
+        }
+
+        It "Should return a list of datastores with the '-datastoreClusters' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -datastoreClusters
+            $results.Count | Should -BeExactly 1
+        }
+
+        It "Should return a list of Networks with the '-networks' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -networks
+            $results.Count | Should -BeExactly 1
+        }
+
+        It "Should return a list of folders with the '-folders' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -folders
+            $results.Count | Should -BeExactly 3
+        }
+
+        It "Should return a list of Host Clusters with the '-hostClusters' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -hostClusters
+            $results.Count | Should -BeExactly 1
+        }
+
+        It "Should return a list of Resource Pools with the '-resourcePools' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -resourcePools
+            $results.Count | Should -BeExactly 1
+        }
+
+        It "Should return a list of VMs with the '-VMs' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -vms
+            $results.Count | Should -BeExactly 4
+        }
+
+        It "Should return a list of LTR Repositories with the '-repositories' switch" {
+            $results = Get-ZertoVirtualizationSite -siteIdentifier '1234' -repositories
+            $results.Count | Should -BeExactly 1
+        }
+
+        Assert-VerifiableMock
+
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/devices'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/devices?hostIdentifier=4567'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/hosts'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/hosts/4567'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/datastores'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/datastoreclusters'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/networks'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/folders'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/hostclusters'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/resourcepools'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/vms'
+        } -Exactly 1
+        Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -ParameterFilter {
+            $uri -eq 'virtualizationsites/1234/repositories'
+        } -Exactly 1
     }
 }
 

--- a/Tests/Public/Mocks/VirtualSite-Folders.json
+++ b/Tests/Public/Mocks/VirtualSite-Folders.json
@@ -1,0 +1,14 @@
+[
+  {
+    "FolderIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.group-v3",
+    "FolderName": "/"
+  },
+  {
+    "FolderIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.group-v27",
+    "FolderName": "Templates"
+  },
+  {
+    "FolderIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.group-v9",
+    "FolderName": "Discovered virtual machine"
+  }
+]

--- a/Tests/Public/Mocks/VirtualSite-Networks.json
+++ b/Tests/Public/Mocks/VirtualSite-Networks.json
@@ -1,0 +1,4 @@
+{
+  "NetworkIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.network-20",
+  "VirtualizationNetworkName": "VM Network"
+}

--- a/Tests/Public/Mocks/VirtualSite-NoParams.json
+++ b/Tests/Public/Mocks/VirtualSite-NoParams.json
@@ -1,0 +1,10 @@
+[
+  {
+    "SiteIdentifier": "8e1c9f53-4973-4a4a-b2dd-1ebb293614d8",
+    "VirtualizationSiteName": "cavc.nc.lab"
+  },
+  {
+    "SiteIdentifier": "15aa0d43-69cd-400a-8b99-fe94bbac3e19",
+    "VirtualizationSiteName": "ncvc.nc.lab"
+  }
+]

--- a/Tests/Public/Mocks/VirtualSite-ResourcePools.json
+++ b/Tests/Public/Mocks/VirtualSite-ResourcePools.json
@@ -1,0 +1,4 @@
+{
+  "ResourcePoolIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.resgroup-8",
+  "ResourcepoolName": "Resources"
+}

--- a/Tests/Public/Mocks/VirtualSite-SiteId.json
+++ b/Tests/Public/Mocks/VirtualSite-SiteId.json
@@ -1,0 +1,4 @@
+{
+  "SiteIdentifier": "8e1c9f53-4973-4a4a-b2dd-1ebb293614d8",
+  "VirtualizationSiteName": "cavc.nc.lab"
+}

--- a/Tests/Public/Mocks/VirtualSite-VMs.json
+++ b/Tests/Public/Mocks/VirtualSite-VMs.json
@@ -1,0 +1,18 @@
+[
+  {
+    "VmIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.vm-55",
+    "VmName": "TimeSeries"
+  },
+  {
+    "VmIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.vm-53",
+    "VmName": "AnsibleTarget"
+  },
+  {
+    "VmIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.vm-28",
+    "VmName": "cazvm.nc.lab"
+  },
+  {
+    "VmIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.vm-26",
+    "VmName": "WinTemplate"
+  }
+]

--- a/Tests/Public/Mocks/VirtualSite-datastoreClusters.json
+++ b/Tests/Public/Mocks/VirtualSite-datastoreClusters.json
@@ -1,0 +1,4 @@
+{
+  "DatastoreClusterIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.group-p44",
+  "DatastoreClusterName": "CA_DS_Cluster"
+}

--- a/Tests/Public/Mocks/VirtualSite-datastores.json
+++ b/Tests/Public/Mocks/VirtualSite-datastores.json
@@ -1,0 +1,34 @@
+[
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-40",
+    "DatastoreName": "MgmtLUN"
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-23",
+    "DatastoreName": "LabPool"
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-22",
+    "DatastoreName": "datastore1 (2)"
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-21",
+    "DatastoreName": "datastore1 (1)"
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-19",
+    "DatastoreName": "datastore1"
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-41",
+    "DatastoreName": "CA_DS_01"
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-42",
+    "DatastoreName": "CA_DS_02"
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-43",
+    "DatastoreName": "CA_DS_03"
+  }
+]

--- a/Tests/Public/Mocks/VirtualSite-devices-hostid.json
+++ b/Tests/Public/Mocks/VirtualSite-devices-hostid.json
@@ -1,0 +1,62 @@
+[
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-40",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.6001405a18009ded4f84d4177d8893d6",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.6001405a18009ded4f84d4177d8893d6)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 1073741824000,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-22",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.mpx.vmhba1:C0:T0:L0",
+    "DeviceName": "Local VMware Disk (mpx.vmhba1:C0:T0:L0)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 42949672960,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-42",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.6001405922cd662dc343d4683d9aecd1",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.6001405922cd662dc343d4683d9aecd1)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 536870912000,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-41",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.6001405522c4ad5d65a6d4113d9657dc",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.6001405522c4ad5d65a6d4113d9657dc)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 536870912000,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-43",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.600140533d732abd8caed42cfda50ed1",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.600140533d732abd8caed42cfda50ed1)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 536870912000,
+    "VmIdentifier": null
+  }
+]

--- a/Tests/Public/Mocks/VirtualSite-devices.json
+++ b/Tests/Public/Mocks/VirtualSite-devices.json
@@ -1,0 +1,62 @@
+[
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-40",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.6001405a18009ded4f84d4177d8893d6",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.6001405a18009ded4f84d4177d8893d6)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 1073741824000,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-22",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.mpx.vmhba1:C0:T0:L0",
+    "DeviceName": "Local VMware Disk (mpx.vmhba1:C0:T0:L0)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 42949672960,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-42",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.6001405922cd662dc343d4683d9aecd1",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.6001405922cd662dc343d4683d9aecd1)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 536870912000,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-41",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.6001405522c4ad5d65a6d4113d9657dc",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.6001405522c4ad5d65a6d4113d9657dc)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 536870912000,
+    "VmIdentifier": null
+  },
+  {
+    "DatastoreIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.datastore-43",
+    "DeviceIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.naa.600140533d732abd8caed42cfda50ed1",
+    "DeviceName": "SYNOLOGY iSCSI Disk (naa.600140533d732abd8caed42cfda50ed1)",
+    "HostIdentifiers": [
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+      "09db6c5b-b956-430f-9589-b58876ca377a.host-12"
+    ],
+    "SizeInBytes": 536870912000,
+    "VmIdentifier": null
+  }
+]

--- a/Tests/Public/Mocks/VirtualSite-hostClusters.json
+++ b/Tests/Public/Mocks/VirtualSite-hostClusters.json
@@ -1,0 +1,4 @@
+{
+  "ClusterIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.domain-c7",
+  "VirtualizationClusterName": "CA Cluster"
+}

--- a/Tests/Public/Mocks/VirtualSite-hosts-hostid.json
+++ b/Tests/Public/Mocks/VirtualSite-hosts-hostid.json
@@ -1,0 +1,4 @@
+{
+  "HostIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+  "VirtualizationHostName": "caesx3.nc.lab"
+}

--- a/Tests/Public/Mocks/VirtualSite-hosts.json
+++ b/Tests/Public/Mocks/VirtualSite-hosts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "HostIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.host-18",
+    "VirtualizationHostName": "caesx3.nc.lab"
+  },
+  {
+    "HostIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.host-15",
+    "VirtualizationHostName": "caesx2.nc.lab"
+  },
+  {
+    "HostIdentifier": "09db6c5b-b956-430f-9589-b58876ca377a.host-12",
+    "VirtualizationHostName": "caesx1.nc.lab"
+  }
+]

--- a/Tests/Public/Mocks/VirtualSite-repositories.json
+++ b/Tests/Public/Mocks/VirtualSite-repositories.json
@@ -1,0 +1,7 @@
+{
+  "ConnectionType": "ServerMessageBlock",
+  "Path": "\\\\192.168.1.150\\zBackups",
+  "RepositoryIdentifier": "120355ce-fcd0-4820-a971-787d0470793b",
+  "RepositoryName": "Synology",
+  "StorageType": "NetworkShare"
+}

--- a/ZertoApiWrapper.Depend.psd1
+++ b/ZertoApiWrapper.Depend.psd1
@@ -19,7 +19,7 @@
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '4.8.1'
+        Version        = '4.10.1'
         Tags           = 'Bootstrap'
     }
 

--- a/ZertoApiWrapper/Public/Get-ZertoVirtualizationSite.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVirtualizationSite.ps1
@@ -133,33 +133,27 @@ function Get-ZertoVirtualizationSite {
             HelpMessage = "The identifier of the Zerto Virtual Manager site."
         )]
         [switch]$repositories
-
     )
 
     begin {
-        $baseUri = "virtualizationsites"
-        $returnObject = @()
+
     }
 
     process {
         # Return information based on ParameterSetName invoked.
+        $baseUri = "virtualizationsites"
         switch ( $PSCmdlet.ParameterSetName ) {
-
             # If no ParameterSetName is specified, return all data
             "main" {
-                $returnObject = Invoke-ZertoRestRequest -uri $baseUri
+                $uri = $baseUri
             }
 
             # If devices is specified along with a hostId, build return just that host information, otherwise return all devices at the site
-            #TODO - remove foreach, only one siteIdentifier can be specified.
             "devices" {
-                $returnObject = foreach ( $id in $siteIdentifier ) {
-                    if ( $PSBoundParameters.ContainsKey( "hostIdentifier" ) ) {
-                        $uri = "{0}/{1}/devices?hostIdentifier={2}" -f $baseUri, $siteIdentifier, $hostIdentifier
-                    } else {
-                        $uri = "{0}/{1}/devices" -f $baseUri, $siteIdentifier
-                    }
-                    Invoke-ZertoRestRequest -uri $uri
+                if ( $PSBoundParameters.ContainsKey( "hostIdentifier" ) ) {
+                    $uri = "{0}/{1}/devices?hostIdentifier={2}" -f $baseUri, $siteIdentifier, $hostIdentifier
+                } else {
+                    $uri = "{0}/{1}/devices" -f $baseUri, $siteIdentifier
                 }
             }
 
@@ -170,24 +164,22 @@ function Get-ZertoVirtualizationSite {
                 } else {
                     $uri = "{0}/{1}/hosts" -f $baseUri, $siteIdentifier
                 }
-                $returnObject = Invoke-ZertoRestRequest -uri $uri
             }
 
             # If siteIdentifier is specified, return information for that site.
             "siteIdentifier" {
                 $uri = "{0}/{1}" -f $baseUri, $siteIdentifier
-                $returnObject = Invoke-ZertoRestRequest -uri $uri
             }
 
             # If a different ParameterSetName is selected, use that information to build the URI and return that information
             default {
                 $uri = "{0}/{1}/{2}" -f $baseUri, $siteIdentifier, $PSCmdlet.ParameterSetName.ToLower()
-                $returnObject = Invoke-ZertoRestRequest -uri $uri
             }
         }
+        Invoke-ZertoRestRequest -uri $uri
     }
 
     end {
-        return $returnObject
+
     }
 }

--- a/ZertoApiWrapper/Public/Get-ZertoVirtualizationSite.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVirtualizationSite.ps1
@@ -52,6 +52,11 @@ function Get-ZertoVirtualizationSite {
             Mandatory = $true,
             HelpMessage = "The identifier of the Zerto Virtual Manager site."
         )]
+        [Parameter(
+            ParameterSetName = "repositories",
+            Mandatory = $true,
+            HelpMessage = "The identifier of the Zerto Virtual Manager site."
+        )]
         [ValidateNotNullOrEmpty()]
         [Alias("siteId")]
         [string]$siteIdentifier,
@@ -121,7 +126,14 @@ function Get-ZertoVirtualizationSite {
             Mandatory = $true,
             HelpMessage = "Return all VMs at the selected site."
         )]
-        [switch]$vms
+        [switch]$vms,
+        [Parameter(
+            ParameterSetName = "repositories",
+            Mandatory = $true,
+            HelpMessage = "The identifier of the Zerto Virtual Manager site."
+        )]
+        [switch]$repositories
+
     )
 
     begin {

--- a/ZertoApiWrapper/Public/Get-ZertoVpgSetting.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoVpgSetting.ps1
@@ -19,7 +19,7 @@ function Get-ZertoVpgSetting {
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $true,
             Mandatory = $true,
-            HelpMessage = "The identifier of the VPG settings object for which information is retrieved."
+            HelpMessage = "The identifier of the VPG settings object for which information is retrieved. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error."
         )]
         [Parameter(
             ParameterSetName = "dayOfWeek",
@@ -149,31 +149,39 @@ function Get-ZertoVpgSetting {
             Mandatory = $true,
             HelpMessage = "The identifier of the VPG settings object for which information is retrieved."
         )]
+        [Parameter(
+            ParameterSetName = "ltr",
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ValueFromRemainingArguments = $true,
+            Mandatory = $true,
+            HelpMessage = "The identifier of the VPG settings object for which information is retrieved."
+        )]
         [ValidateNotNullOrEmpty()]
         [Alias("vpgSettingsId", "settingsId")]
         [string[]]$vpgSettingsIdentifier,
         [Parameter(
             ParameterSetName = "backup",
             Mandatory = $true,
-            HelpMessage = "Return backup information for VPG identifier specified"
+            HelpMessage = "Return backup information for VPG identifier specified. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error."
         )]
         [switch]$backup,
         [Parameter(
             ParameterSetName = "dayOfWeek",
             Mandatory = $true,
-            HelpMessage = "Get the day of week a backup is scheduled"
+            HelpMessage = "Get the day of week a backup is scheduled. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error."
         )]
         [switch]$dayOfWeek,
         [Parameter(
             ParameterSetName = "retentionPeriod",
             Mandatory = $true,
-            HelpMessage = "Get the retention period for a backup"
+            HelpMessage = "Get the retention period for a backup. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error."
         )]
         [switch]$retentionPeriod,
         [Parameter(
             ParameterSetName = "schedulerPeriod",
             Mandatory = $true,
-            HelpMessage = "Get the backup schedule"
+            HelpMessage = "Get the backup schedule. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error."
         )]
         [switch]$schedulerPeriod,
         [Parameter(
@@ -280,7 +288,14 @@ function Get-ZertoVpgSetting {
         )]
         [ValidateNotNullOrEmpty()]
         [Alias("volumeId")]
-        [string]$volumeIdentifier
+        [string]$volumeIdentifier,
+        [Parameter(
+            ParameterSetName = "ltr",
+            Mandatory = $true,
+            HelpMessage = "Return LTR information for the specified VPG. Please note, this parameter is ONLY available in Zerto version 8.0 and later. Attempting to run this switch against a Zerto Virtual Manager version 7.5 or lower will result in an error."
+        )]
+        [switch]$ltr
+
     )
 
     begin {

--- a/docs/Get-ZertoVirtualizationSite.md
+++ b/docs/Get-ZertoVirtualizationSite.md
@@ -18,6 +18,11 @@ Returns information about the hypervisor site where the API is run and all the s
 Get-ZertoVirtualizationSite [<CommonParameters>]
 ```
 
+### repositories
+```
+Get-ZertoVirtualizationSite -siteIdentifier <String> [-repositories] [<CommonParameters>]
+```
+
 ### folders
 ```
 Get-ZertoVirtualizationSite -siteIdentifier <String> [-folders] [<CommonParameters>]
@@ -225,6 +230,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -repositories
+The identifier of the Zerto Virtual Manager site.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: repositories
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -resourcePools
 Return all resource pools at the selected site.
 
@@ -245,7 +265,7 @@ The identifier of the Zerto Virtual Manager site.
 
 ```yaml
 Type: String
-Parameter Sets: folders, devices, vms, resourcePools, networks, hosts, hostClusters, datastores, datastoreClusters, siteIdentifier
+Parameter Sets: repositories, folders, devices, vms, resourcePools, networks, hosts, hostClusters, datastores, datastoreClusters, siteIdentifier
 Aliases: siteId
 
 Required: True
@@ -271,7 +291,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-ZertoVpgSetting.md
+++ b/docs/Get-ZertoVpgSetting.md
@@ -17,6 +17,11 @@ Returns information when a VPG Settings object is created to create a new or edi
 Get-ZertoVpgSetting [<CommonParameters>]
 ```
 
+### ltr
+```
+Get-ZertoVpgSetting -vpgSettingsIdentifier <String[]> [-ltr] [<CommonParameters>]
+```
+
 ### volumeIdentifier
 ```
 Get-ZertoVpgSetting -vpgSettingsIdentifier <String[]> -vmIdentifier <String> -volumeIdentifier <String>
@@ -151,10 +156,17 @@ PS C:\> Get-ZertoVpgSetting -vpgSettingsIdentifier "MySettingsIdentifier" -basic
 
 Returns current basic settings for vpgSettingsIdentifier "MySettingsIdentifier"
 
+### Example 6
+```powershell
+PS C:\> Get-ZertoVpgSetting -vpgSettingsIdentifier "MySettingsIdentifier" -ltr
+```
+
+Returns current LTR settings for vpgSettingsIdentifier "MySettingsIdentifier"
+
 ## PARAMETERS
 
 ### -backup
-Return backup information for VPG identifier specified
+Return backup information for VPG identifier specified. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error.
 
 ```yaml
 Type: SwitchParameter
@@ -199,7 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### -dayOfWeek
-Get the day of week a backup is scheduled
+Get the day of week a backup is scheduled. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error.
 
 ```yaml
 Type: SwitchParameter
@@ -219,6 +231,21 @@ Get VPG Journal Settings
 ```yaml
 Type: SwitchParameter
 Parameter Sets: journal
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ltr
+Return LTR information for the specified VPG. Please note, this parameter is ONLY available in Zerto version 8.0 and later. Attempting to run this switch against a Zerto Virtual Manager version 7.5 or lower will result in an error.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ltr
 Aliases:
 
 Required: True
@@ -304,7 +331,7 @@ Accept wildcard characters: False
 ```
 
 ### -retentionPeriod
-Get the retention period for a backup
+Get the retention period for a backup. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error.
 
 ```yaml
 Type: SwitchParameter
@@ -319,7 +346,7 @@ Accept wildcard characters: False
 ```
 
 ### -schedulerPeriod
-Get the backup schedule
+Get the backup schedule. Please note, this parameter is ONLY available in Zerto version 7.5 and earlier. Attempting to run this switch against a Zerto Virtual Manager version 8.0 or higher result in an error.
 
 ```yaml
 Type: SwitchParameter
@@ -413,7 +440,7 @@ The identifier of the VPG settings object for which information is retrieved.
 
 ```yaml
 Type: String[]
-Parameter Sets: volumeIdentifier, volumes, nicIdentifier, nics, vmIdentifier, vms, scripting, recovery, priority, networks, journal, bootGroup, basic, schedulerPeriod, retentionPeriod, dayOfWeek, backup, vpgSettingsIdentifier
+Parameter Sets: ltr, volumeIdentifier, volumes, nicIdentifier, nics, vmIdentifier, vms, scripting, recovery, priority, networks, journal, bootGroup, basic, schedulerPeriod, retentionPeriod, dayOfWeek, backup, vpgSettingsIdentifier
 Aliases: vpgSettingsId, settingsId
 
 Required: True
@@ -424,7 +451,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
Updated `Get-ZertoVirtualizationSite` and `Get-ZertoVpgSetting` functions for new ZVM 8.0 functionality. Updated help files with examples for new functionality. Added Tests for Get-`ZertoVirtualizationSite`. Will add testing for `Get-ZertoVpgSetting` at a later date.