### PR TITLE
Get zerto event fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project is transitioning to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Zerto Virtual Manager
+
+#### Fixed
+
+* Updated `Get-ZertoEvent` to translate a vpg name parameter to a vpgIdentifier string per the API documentation
+
 ## [1.4.1]
 
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project is transitioning to [Semantic Versioning](https://semver.org/sp
 
 #### Fixed
 
-* Updated `Get-ZertoEvent` to translate a vpg name parameter to a vpgIdentifier string per the API documentation
+* Updated `Get-ZertoEvent` to translate a vpg name parameter to a vpgIdentifier  per the API documentation
 
 ## [1.4.1]
 

--- a/Tests/Public/Get-ZertoEvent.Tests.ps1
+++ b/Tests/Public/Get-ZertoEvent.Tests.ps1
@@ -12,7 +12,7 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
         $ParameterTestCases = @(
             @{ParameterName = 'startDate'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }
             @{ParameterName = 'endDate'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }
-            @{ParameterName = 'vpgName'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }
+            @{ParameterName = 'vpg'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }
             @{ParameterName = 'vpgIdentifier'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }
             @{ParameterName = 'eventType'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }
             @{ParameterName = 'siteName'; Type = 'String'; Mandatory = $false; Validation = 'NotNullOrEmpty' }

--- a/ZertoApiWrapper/Public/Get-ZertoEvent.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoEvent.ps1
@@ -19,8 +19,8 @@ function Get-ZertoEvent {
             HelpMessage = "The name of the VPG for which you want to return events."
         )]
         [ValidateNotNullOrEmpty()]
-        [Alias("vpg")]
-        [string]$vpgName,
+        [Alias("vpgName")]
+        [string]$vpg,
         [Parameter(
             ParameterSetName = "filter",
             HelpMessage = "The identifier of the VPG for which you want to return events."
@@ -137,6 +137,10 @@ function Get-ZertoEvent {
             # If a filter is applied, create the filter and return the events that fall in that filter
             "filter" {
                 $filter = Get-ZertoApiFilter -filterTable $PSBoundParameters
+                if ($PSBoundParameters.Keys -contains 'vpg') {
+                    $vpgIdentifier = (Get-ZertoVpg -name $vpg).vpgIdentifier
+                    $filter = $filter.replace("vpg=$vpg", "vpg=$vpgIdentifier")
+                }
                 $uri = "{0}{1}" -f $baseUri, $filter
                 $returnObject = Invoke-ZertoRestRequest -uri $uri
             }


### PR DESCRIPTION
`Get-ZertoEvent` When filtering on Vpg or VpgName the API expects a VpgIdentifier value and not a name. Edited the code to lookup the VpgIdentifier and replace the vpgname with the vpgIdentifier value in the query string.