### PR TITLE
Fix Invoke-ZertoMoveCommit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project is transitioning to [Semantic Versioning](https://semver.org/sp
 
 #### Fixed
 
-* Updated `Get-ZertoEvent` to translate a vpg name parameter to a vpgIdentifier  per the API documentation
+* Updated `Get-ZertoEvent` to translate a vpg name parameter to a vpgIdentifier per the API documentation
+* Updated `Invoke-ZertoMoveCommit` to ensure that when one of the parameter switches is defined, all required parameters are sent to avoid conflicts with parameters passed with the `Invoke-ZertoMove` command.
 
 ## [1.4.1]
 

--- a/ZertoApiWrapper/Public/Invoke-ZertoMoveCommit.ps1
+++ b/ZertoApiWrapper/Public/Invoke-ZertoMoveCommit.ps1
@@ -23,8 +23,10 @@ function Invoke-ZertoMoveCommit {
         $body = @{ }
         if ($reverseProtection) {
             $body["ReverseProtection"] = $true
+            $body["KeepSourceVms"] = $false
         } elseif ($keepSourceVms) {
             $body["KeepSourceVms"] = $true
+            $body["ReverseProtection"] = $false
         }
     }
 

--- a/ZertoApiWrapper/Public/Invoke-ZertoMoveCommit.ps1
+++ b/ZertoApiWrapper/Public/Invoke-ZertoMoveCommit.ps1
@@ -1,6 +1,6 @@
 <# .ExternalHelp ./en-us/ZertoApiWrapper-help.xml #>
 function Invoke-ZertoMoveCommit {
-    [cmdletbinding(SupportsShouldProcess = $true)]
+    [cmdletbinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Main")]
     param(
         [Parameter(
             HelpMessage = "Name(s) of the VPG(s) to commit.",
@@ -9,11 +9,16 @@ function Invoke-ZertoMoveCommit {
         [ValidateNotNullOrEmpty()]
         [string[]]$vpgName,
         [Parameter(
-            HelpMessage = "Set this to True to reverse protect the VPG(s) to the source site. If not set, will use selection made during move initiation. True or False"
+            HelpMessage = "Use this switch to reverse protect the VPG(s) to the source site. If neither 'ReverseProtction' nor 'KeepSourceVms' switch is specified, the commit process will use selection made during move initiation.",
+            ParameterSetName = 'ReverseProtect',
+            Mandatory
+
         )]
         [switch]$reverseProtection,
         [Parameter(
-            HelpMessage = "Use this switch to keep the source VMs. If not set, they will be destroyed."
+            HelpMessage = "Use this switch to keep the source VMs at the source site. If neither 'ReverseProtction' nor 'KeepSourceVms' switch is specified, the commit process will use selection made during move initiation.",
+            ParameterSetName = 'KeepSource',
+            Mandatory
         )]
         [switch]$keepSourceVms
     )
@@ -21,12 +26,16 @@ function Invoke-ZertoMoveCommit {
     begin {
         $baseUri = "vpgs"
         $body = @{ }
-        if ($reverseProtection) {
-            $body["ReverseProtection"] = $true
-            $body["KeepSourceVms"] = $false
-        } elseif ($keepSourceVms) {
-            $body["KeepSourceVms"] = $true
-            $body["ReverseProtection"] = $false
+        Switch ($PSCmdlet.ParameterSetName){
+            'KeepSource' {
+                $body["KeepSourceVms"] = $true
+                $body["ReverseProtection"] = $false
+            }
+
+            'ReverseProtect' {
+                $body["ReverseProtection"] = $true
+                $body["KeepSourceVms"] = $false
+            }
         }
     }
 

--- a/docs/Get-ZertoEvent.md
+++ b/docs/Get-ZertoEvent.md
@@ -112,6 +112,7 @@ The type of event to return. This filter behaves in the same way as the eventCat
 Type: String
 Parameter Sets: filter
 Aliases:
+Accepted values: All, Events, Alerts
 
 Required: False
 Position: Named
@@ -159,6 +160,7 @@ The type of entity for which you wish to return results. Possible Values are: 'V
 Type: String
 Parameter Sets: filter
 Aliases:
+Accepted values: VPG, VRA, Unknown, Site
 
 Required: False
 Position: Named
@@ -174,6 +176,7 @@ This filter behaves in the same way as the category filter. If both category and
 Type: String
 Parameter Sets: filter
 Aliases:
+Accepted values: All, Events, Alerts
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoProtectedVm.md
+++ b/docs/Get-ZertoProtectedVm.md
@@ -88,6 +88,7 @@ The priority specified for the VPG. Possible values are: 'Low', 'Medium', or 'Hi
 Type: String
 Parameter Sets: filter
 Aliases:
+Accepted values: Low, Medium, High
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoRecoveryReport.md
+++ b/docs/Get-ZertoRecoveryReport.md
@@ -102,6 +102,7 @@ Possible values are: 'Failover', 'Failover Test', or 'Move'
 Type: String
 Parameter Sets: filter
 Aliases:
+Accepted values: Failover, Failover Test, Move
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoTask.md
+++ b/docs/Get-ZertoTask.md
@@ -129,6 +129,7 @@ The status of the task. Possible values are: 'InProgress', 'Paused', 'Failed', '
 Type: String
 Parameter Sets: filter
 Aliases:
+Accepted values: InProgress, Paused, Failed, Completed, Cancelling
 
 Required: False
 Position: Named

--- a/docs/Get-ZertoVpg.md
+++ b/docs/Get-ZertoVpg.md
@@ -271,6 +271,7 @@ The VPG priority. Possible values are: 'Low', 'Medium', 'High'
 Type: String
 Parameter Sets: filter
 Aliases:
+Accepted values: Low, Medium, High
 
 Required: False
 Position: Named

--- a/docs/Invoke-ZertoMoveCommit.md
+++ b/docs/Invoke-ZertoMoveCommit.md
@@ -12,9 +12,19 @@ Commit a VPG currently undergoing a move operation.
 
 ## SYNTAX
 
+### Main (Default)
 ```
-Invoke-ZertoMoveCommit [-vpgName] <String[]> [-reverseProtection] [-keepSourceVms] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Invoke-ZertoMoveCommit -vpgName <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### ReverseProtect
+```
+Invoke-ZertoMoveCommit -vpgName <String[]> [-reverseProtection] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### KeepSource
+```
+Invoke-ZertoMoveCommit -vpgName <String[]> [-keepSourceVms] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,20 +37,33 @@ Commit a VPG currently undergoing a move operation.
 PS C:\> Invoke-ZertoMoveCommit -vpgName "MyVpg"
 ```
 
-Commit VPG "MyVpg" after a move has been started.
+Commit VPG "MyVpg" after a move operation has been completed. This commit process with use the `-KeepSourceVms` or `-ReverseProtection` selection made during the move initation.
+
+### Example 2
+```powershell
+PS C:\> Invoke-ZertoMoveCommit -vpgName "MyVpg" -keepSourceVms
+```
+
+Commit VPG "MyVpg" after a move operation has been completed specifying to keep the vms at the source location and NOT reverse protection. This commit process will overrule any reverse protection or keep source vms selection made during the move initiation.
+
+### Example 3
+```powershell
+PS C:\> Invoke-ZertoMoveCommit -vpgName "MyVpg" -reverseProtection
+```
+
+Commit VPG "MyVpg" after a move operation has been completed specifying to reverse protection of the VMs back to the source location. The VMs at the source location will be removed from inventory at the source location and the disks will be used as pre-seed volumes. This commit process will overrule any reverse protection or keep source vms selection made during the move initiation.
 
 ## PARAMETERS
 
 ### -keepSourceVms
-Use this switch to keep the source VMs.
-If not set, they will be destroyed.
+"Use this switch to keep the source VMs at the source site. If neither 'ReverseProtction' nor 'KeepSourceVms' switch is specified, the commit process will use selection made during move initiation."
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: KeepSource
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -48,14 +71,14 @@ Accept wildcard characters: False
 ```
 
 ### -reverseProtection
-Set this to True to reverse protect the VPG(s) to the source site. If not set, will use selection made during move initiation. True or False
+"Use this switch to reverse protect the VPG(s) to the source site. If neither 'ReverseProtction' nor 'KeepSourceVms' switch is specified, the commit process will use selection made during move initiation."
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: ReverseProtect
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -71,7 +94,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
During a Move process, if a selection is made to reverse replicate during the commit process if the selection is changed to keep source VMs the process will fail. This update changes it so that it will disable reverse protection and keep source vms when desired. Also, the inverse it true now as well.