### PR TITLE
Fix zerto start clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project is transitioning to [Semantic Versioning](https://semver.org/sp
 
 * Updated `Get-ZertoEvent` to translate a vpg name parameter to a vpgIdentifier per the API documentation
 * Updated `Invoke-ZertoMoveCommit` to ensure that when one of the parameter switches is defined, all required parameters are sent to avoid conflicts with parameters passed with the `Invoke-ZertoMove` command.
+* Updated `Start-ZertoCloneVpg` to fix an issue where an error would be thrown if an operation specified a subset of VMs to be cloned.
 
 ## [1.4.1]
 

--- a/ZertoApiWrapper/Public/Start-ZertoCloneVpg.ps1
+++ b/ZertoApiWrapper/Public/Start-ZertoCloneVpg.ps1
@@ -62,32 +62,20 @@ function Start-ZertoCloneVpg {
                 }
             }
             $body['VmIdentifiers'] = $vmIdentifiers
-            if ($checkpointIdentifier) {
-                $body['CheckpointIdentifier'] = $checkpointIdentifier
-            }
         }
-    }
-
-    process {
-        $uri = "{0}/{1}/CloneStart" -f $baseUri, $vpgIdentifier
-        $body = [ordered]@{ }
         if ( $PSBoundParameters.ContainsKey('checkpointIdentifier') ) {
             $body['checkpointId'] = $checkpointIdentifier
         }
-        if ( $datastoreIdentifier ) {
-            $body['DatastoreIdentifier'] = $datastoreIdentifier
-        }
-        if ( $vmIdentifiers ) {
-            $body['VmIdentifiers'] = $vmIdentifiers
-        }
         Write-Verbose $body
+        $uri = "{0}/{1}/CloneStart" -f $baseUri, $vpgIdentifier
         if ($PSCmdlet.ShouldProcess("Clone Vpg")) {
             Invoke-ZertoRestRequest -uri $uri -body $($body | ConvertTo-Json) -method "POST"
+            Write-Verbose "Call Submitted to $uri"
+            Write-Verbose "With the following information: $($body | ConvertTo-Json)"
         }
     }
 
     end {
-        Write-Verbose "Call Submitted to $uri"
-        Write-Verbose "With the following information: $($body | ConvertTo-Json)"
+
     }
 }

--- a/ZertoApiWrapper/Public/Start-ZertoCloneVpg.ps1
+++ b/ZertoApiWrapper/Public/Start-ZertoCloneVpg.ps1
@@ -27,18 +27,25 @@ function Start-ZertoCloneVpg {
     )
 
     begin {
+
+    }
+
+    process {
         $baseUri = "vpgs"
         $vpgInfo = Get-ZertoVpg -name $vpgName
         if ( -not $vpgInfo ) {
             Write-Error "VPG: $vpgName could not be found. Please check the name and try again."
         }
         $vpgIdentifier = $vpgInfo.vpgIdentifier
+        $body = @{ }
         if ( $PSBoundParameters.ContainsKey('datastoreName') ) {
             $recoverysiteIdentifier = $vpgInfo.recoverysite.identifier
             $recoverySiteDatastores = Get-ZertoVirtualizationSite -siteIdentifier $recoverysiteIdentifier -datastores
             $datastoreIdentifier = $($recoverySiteDatastores | Where-Object { $_.datastoreName -like $datastoreName }).DatastoreIdentifier
             if ( -not $datastoreIdentifier ) {
                 Write-Error "Datastore: $datastoreName is not a valid datastore. Please check the name and try again." -ErrorAction Stop
+            } else {
+                $body['DatastoreIdentifier'] = $datastoreIdentifier
             }
         }
         if ( $PSBoundParameters.ContainsKey('vmName') ) {


### PR DESCRIPTION
Fixes and issue with `Start-ZertoVpgClone` where an error would be thrown if a subset of VMs was specified to be cloned. Also updated the workflow to move the entire operation into the process block.
