### PR TITLE
Make New-ZertoVpg -RecoverySite parameter case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project is transitioning to [Semantic Versioning](https://semver.org/sp
 
 * Updated `Connect-ZertoServer` with a `-AutoReconnect` switch to allow the auto reconnection of a session that has timed-out.
 * Updated `New-ZertoVpg` to have a Default Parameter Set of `recoveryHostDatastore` should no parameters be passed when calling the function.
+* Updated `New-ZertoVpg -recoverySite` parameter to be case-insensitive
 
 ## [1.4.2]
 

--- a/ZertoApiWrapper/Public/New-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/New-ZertoVpg.ps1
@@ -165,7 +165,7 @@ function New-ZertoVpg {
     begin {
         # Create an identifiers table, and start converting names to identifiers.
         $identifiersTable = @{ }
-        $identifiersTable['recoverySiteIdentifier'] = $(Get-ZertoPeerSite -peerName $recoverySite).siteIdentifier
+        $identifiersTable['recoverySiteIdentifier'] = (Get-ZertoPeerSite).Where({$_.PeerSiteName -like $recoverySite}) | Select-Object -ExpandProperty SiteIdentifier
         $peerSiteNetworks = $(Get-ZertoVirtualizationSite -siteIdentifier $identifiersTable['recoverySiteIdentifier'] -networks)
         $identifiersTable['failoverNetworkIdentifier'] = $peerSiteNetworks | Where-Object { $_.VirtualizationNetworkName -like $recoveryNetwork } | Select-Object -ExpandProperty NetworkIdentifier
         $identifiersTable['testNetworkIdentifier'] = $peerSiteNetworks | Where-Object { $_.VirtualizationNetworkName -like $testNetwork } | Select-Object -ExpandProperty NetworkIdentifier


### PR DESCRIPTION
Fixes #90 

Currently New-ZertoVpg -recoverySite is case-sensitive due to the API filter used. This change updates the function to not use the native filter, but filter based on the data returned using a case-insensitive matching operator.