### PR TITLE
Remove zvmLocalInfo Script Scope Variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project is transitioning to [Semantic Versioning](https://semver.org/sp
 #### Fixed
 
 * Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/96) with `Set-ZertoLicense` so that ShouldProcess functions properly.
+* Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/95) when attempting to connect to an unlicensed site.
 
 ## [1.4.2]
 

--- a/Tests/Public/Connect-ZertoServer.Tests.ps1
+++ b/Tests/Public/Connect-ZertoServer.Tests.ps1
@@ -67,10 +67,6 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
             return $results
         }
 
-        Mock -ModuleName ZertoApiWrapper -CommandName Get-ZertoLocalSite {
-            return (Get-Content -Path "$global:here\Mocks\LocalSiteInfo.json" -Raw | ConvertFrom-Json)
-        }
-
         Context "$($global:function)::InModuleScope Function Unit Tests" {
 
             BeforeAll {
@@ -138,7 +134,6 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
             }
 
             Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Invoke-ZertoRestRequest -Exactly 4
-            Assert-MockCalled -ModuleName ZertoApiWrapper -CommandName Get-ZertoLocalSite -Exactly 4
         }
     }
 }

--- a/Tests/Public/Connect-ZertoServer.Tests.ps1
+++ b/Tests/Public/Connect-ZertoServer.Tests.ps1
@@ -106,12 +106,6 @@ Describe $global:function -Tag 'Unit', 'Source', 'Built' {
                 $script:zvmHeaders['Accept'] | Should -BeOfType String
             }
 
-            It "Module Scope zvmLocalInfo variable tests" {
-                $script:zvmLocalInfo | Should -Not -BeNullOrEmpty
-                $script:zvmLocalInfo | Should -BeOfType PSCustomObject
-                $script:zvmLocalInfo.SiteIdentifier | Should -BeOfType String
-            }
-
             $headers = Connect-ZertoServer -zertoServer $Server -credential $credential -returnHeaders
             It "returns a Hashtable with 2 keys" {
                 $headers | Should -BeOfType Hashtable

--- a/ZertoApiWrapper/Public/Connect-ZertoServer.ps1
+++ b/ZertoApiWrapper/Public/Connect-ZertoServer.ps1
@@ -62,10 +62,7 @@ function Connect-ZertoServer {
     end {
         # Build Headers Hashtable with Authorization Token
         $Script:zvmHeaders['x-zerto-session'] = $results.Headers['x-zerto-session'][0].ToString()
-        # Set common Script Scope Variables to be used other functions (Headers and Local Site Info)
-        # Set-Variable -Name zvmHeaders -Scope Script -Value $zertoAuthorizationHeaders
-        Set-Variable -Name zvmLocalInfo -Scope Script -Value (Get-ZertoLocalSite)
-
+        
         # Have the option to return the headers to a variable
         if ($returnHeaders) {
             return $Script:zvmHeaders

--- a/ZertoApiWrapper/Public/Disconnect-ZertoServer.ps1
+++ b/ZertoApiWrapper/Public/Disconnect-ZertoServer.ps1
@@ -12,5 +12,4 @@ function Disconnect-ZertoServer {
     Remove-Variable -Name zvmPort -Scope Script
     Remove-Variable -Name zvmLastAction -Scope Script
     Remove-Variable -Name zvmHeaders -Scope Script
-    Remove-Variable -Name zvmLocalInfo -Scope Script
 }

--- a/ZertoApiWrapper/Public/Get-ZertoUnprotectedVm.ps1
+++ b/ZertoApiWrapper/Public/Get-ZertoUnprotectedVm.ps1
@@ -2,6 +2,6 @@
 function Get-ZertoUnprotectedVm {
     [cmdletbinding()]
     param()
-    $uri = "virtualizationsites/{0}/vms" -f $script:zvmLocalInfo.siteidentifier
+    $uri = "virtualizationsites/{0}/vms" -f (Get-ZertoLocalSite).siteIdentifier
     Invoke-ZertoRestRequest -uri $uri
 }

--- a/ZertoApiWrapper/Public/Install-ZertoVra.ps1
+++ b/ZertoApiWrapper/Public/Install-ZertoVra.ps1
@@ -111,7 +111,7 @@ function Install-ZertoVra {
         # If the VRA does not exist, proceed with the installation. If it does exist, bypass and
         if ( -not (Get-ZertoVra -vraName $vraName) ) {
             # Get identifiers for each item provided by name.
-            $siteIdentifier = $script:zvmLocalInfo.SiteIdentifier
+            $siteIdentifier = (Get-ZertoLocalSite).SiteIdentifier
             $hostIdentifier = Get-ZertoVirtualizationSite -siteIdentifier $siteIdentifier -hosts | Where-Object { $_.VirtualizationHostName -eq $hostName } | Select-Object hostIdentifier -ExpandProperty hostIdentifier
             $networkIdentifier = Get-ZertoVirtualizationSite -siteIdentifier $siteIdentifier -networks | Where-Object { $_.VirtualizationNetworkName -eq $networkName } | Select-Object NetworkIdentifier -ExpandProperty NetworkIdentifier
             $datastoreIdentifier = Get-ZertoVirtualizationSite -siteIdentifier $siteIdentifier -datastores | Where-Object { $_.DatastoreName -eq $datastoreName } | Select-Object DatastoreIdentifier -ExpandProperty DatastoreIdentifier


### PR DESCRIPTION
Fixes #95 

During the `Connect-ZertoServer` function call, a script scope variable was initially set to reduce the number of API requests during subsequent operations. The issue was that this call required a valid license and when attempting to set a license would throw and error causing confusion.

This fix removes the script scope variable and updates all locations where the variable was used with a call to get the required information.

Tests have been updated as well.