### PR TITLE
Fixed issue 108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project is transitioning to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Zerto Virtual Manager
+
+#### Fixed
+
+* Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/108) with `New-ZertoVpg` where the Host Identifier was incorrect when inputting a single recovery host, changed to recoveryHostIdentifier.
+
 ## [1.5.0]
 
 ### Zerto Virtual Manager

--- a/ZertoApiWrapper/Public/New-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/New-ZertoVpg.ps1
@@ -295,11 +295,11 @@ function New-ZertoVpg {
 
             "recoveryHostDatastoreCluster" {
                 $baseSettings.Recovery.DefaultDatastoreClusterIdentifier = $identifiersTable['datastoreClusterIdentifier']
-                $baseSettings.Recovery.DefaultHostIdentifier = $identifiersTable['hostIdentifier']
+                $baseSettings.Recovery.DefaultHostIdentifier = $identifiersTable['recoveryHostIdentifier']
             }
 
             "recoveryHostDatastore" {
-                $baseSettings.Recovery.DefaultHostIdentifier = $identifiersTable['hostIdentifier']
+                $baseSettings.Recovery.DefaultHostIdentifier = $identifiersTable['recoveryHostIdentifier']
                 $baseSettings.Recovery.DefaultDatastoreIdentifier = $identifiersTable['datastoreIdentifier']
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Issue with using New-ZertoVpg Script, where if a single host was entered the script would error out.  Found that the parameter used was incorrect and modified to correct parameter.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #108 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixed issue with New-ZertoVpg to be able to utilize a single recovery host as an input.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with updating the correct parameter and executed successfully in lab environment with no issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

