### PR TITLE
SiteId Query to VirtualizationSites Fixes #112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project is transitioning to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Zerto Virtual Manager
+
+#### Fixed
+
+* Fixed an [issue](https://github.com/ZertoPublic/ZertoApiWrapper/issues/112) where `New-ZertoVpg` would fail when specifying the localsite as the target site.
+
 ## [1.5.2]
 
 ### Zerto Virtual Manager

--- a/ZertoApiWrapper/Public/New-ZertoVpg.ps1
+++ b/ZertoApiWrapper/Public/New-ZertoVpg.ps1
@@ -165,7 +165,7 @@ function New-ZertoVpg {
     begin {
         # Create an identifiers table, and start converting names to identifiers.
         $identifiersTable = @{ }
-        $identifiersTable['recoverySiteIdentifier'] = (Get-ZertoPeerSite).Where({$_.PeerSiteName -like $recoverySite}) | Select-Object -ExpandProperty SiteIdentifier
+        $identifiersTable['recoverySiteIdentifier'] = (Get-ZertoVirtualizationSite).Where( { $_.VirtualizationSiteName -like $recoverySite }) | Select-Object -ExpandProperty SiteIdentifier
         $peerSiteNetworks = $(Get-ZertoVirtualizationSite -siteIdentifier $identifiersTable['recoverySiteIdentifier'] -networks)
         $identifiersTable['failoverNetworkIdentifier'] = $peerSiteNetworks | Where-Object { $_.VirtualizationNetworkName -like $recoveryNetwork } | Select-Object -ExpandProperty NetworkIdentifier
         $identifiersTable['testNetworkIdentifier'] = $peerSiteNetworks | Where-Object { $_.VirtualizationNetworkName -like $testNetwork } | Select-Object -ExpandProperty NetworkIdentifier


### PR DESCRIPTION
Updates the method to grab the target site id to allow for local replication target.

## Description
Changes the method to grab the target site id from `Get-ZertoPeerSite` to `Get-ZertoVirtualizationSite`. This method will include local site should local replication be desired.

## Related Issue
Fixes #112 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran automated tests.
Created a VPG targeting the same site as the source.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

